### PR TITLE
fix: remove limiter package from noncompat list

### DIFF
--- a/content/docs/introduction.md
+++ b/content/docs/introduction.md
@@ -20,7 +20,6 @@ If you maintain a package and need help with migrating your package to be compat
 If your applications relies on the following packages, then please wait for another few weeks as we get these packages compatible with v6.
 
 - [Drive](http://github.com/adonisjs/drive)
-- [Limiter](https://github.com/adonisjs/limiter)
 - [Attachment lite](https://github.com/adonisjs/attachment-lite)
 - [Lucid Slugify](https://github.com/adonisjs/lucid-slugify)
 - [Route model binding](https://github.com/adonisjs/route-model-binding)


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Since rate limited is supported in v6 now, let's remove the package from the non-compatability list :)

https://docs.adonisjs.com/guides/rate-limiter#dynamic-rate-limiting
https://v6-migration.adonisjs.com/guides/introduction#official-packages-not-yet-compatible-with-v6

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
