### PR TITLE
fix: correct typo (if you're not ready to move to AdonisJS *v6*, not *v5*)

### DIFF
--- a/content/docs/other/stick_to_v5.md
+++ b/content/docs/other/stick_to_v5.md
@@ -1,6 +1,6 @@
 # Sticking to V5
 
-If you are not ready to migrate your application to AdonisJS v5, no worries. Just make sure to pin the following packages to these versions. Major versions above will be for AdonisJS 6 only.
+If you are not ready to migrate your application to AdonisJS v6, no worries. Just make sure to pin the following packages to these versions. Major versions above will be for AdonisJS 6 only.
 
 If you want to stick to v5, you should have the same major versions as the following :
 


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Fixes a typo. It says "if you're not ready to move to AdonisJS v5...", when it should say "if you're not ready to move to AdonisJS v6". 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
